### PR TITLE
ci: Add templates for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug.yml
@@ -1,0 +1,17 @@
+name: 🪲 Bug report
+description: 'Report a bug or unexpected behavior'
+labels: [bug]
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Please provide as much detail as possible to make understanding and solving your problem as quick as possible. 🙏
+        - What happens?
+        - What were you expecting to happen?
+        - What are the steps to reproduce this issue?
+        - Any logs, error output, etc?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.yml
@@ -1,0 +1,23 @@
+name: 💡 Feature request
+description: 'Suggest an idea for this project'
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Please give as much detail as possible about the feature you would like to suggest. 🙏
+        - Is your feature request related to a problem?
+        - What were you trying to accomplish and how would you like to do it differently?
+        - Is there something you currently cannot do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: |
+        Please outline the motivation for the proposal.
+        Why is this feature important to you? How can it benefit other users?


### PR DESCRIPTION
I was starting to write issues to this project but the blank issue window confused me a lot. that is why I decided to make a research and make a proposal with basic fillings of "feature request" and "bug" issues