### PR TITLE
fix(manager): Add log before stopping the DAG run

### DIFF
--- a/ml_pipeline_engine/dag/manager.py
+++ b/ml_pipeline_engine/dag/manager.py
@@ -162,7 +162,7 @@ class DAGRunConcurrentManager(DAGRunManagerLike):
 
             return self._get_dag_result()
         except Exception as ex:
-            logger.debug('DAG run raised error :  %s', repr(ex))
+            logger.error('DAG run raised error', exc_info=ex)
             raise
         finally:
             self._stop_coro_tasks(*self._coro_tasks)

--- a/ml_pipeline_engine/dag/manager.py
+++ b/ml_pipeline_engine/dag/manager.py
@@ -161,7 +161,9 @@ class DAGRunConcurrentManager(DAGRunManagerLike):
             )
 
             return self._get_dag_result()
-
+        except Exception as ex:
+            logger.debug('DAG run raised error :  %s', repr(ex))
+            raise
         finally:
             self._stop_coro_tasks(*self._coro_tasks)
 


### PR DESCRIPTION
We need this additional log to figure out the potential problem that caused tasks and DAG to suddenly stop.