### PR TITLE
Feat/fix oneof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .pytest_cache
 /public
 /build
+.venv/

--- a/ml_pipeline_engine/dag/storage.py
+++ b/ml_pipeline_engine/dag/storage.py
@@ -52,9 +52,20 @@ class DAGNodeStorage:
     switch_results: HiddenDict = field(default_factory=HiddenDict)
     recurrent_subgraph: HiddenDict = field(default_factory=HiddenDict)
     waiting_list: HiddenDict = field(default_factory=HiddenDict)
+    node_unhandled_errors: HiddenDict = field(default_factory=HiddenDict)
 
     def set_node_result(self, node_id: NodeId, data: t.Any) -> None:
         self.node_results.set(node_id, data)
+
+    def set_node_unhandled_error(self, node_id: NodeId, data: t.Any) -> None:
+        self.node_unhandled_errors.set(node_id, data)
+
+    def get_node_unhandled_error(self, node_id: NodeId, with_hidden: bool = False) -> t.Any:
+        return self.node_unhandled_errors.get(node_id, with_hidden)
+
+    def exists_node_unhandled_error(self, node_id: NodeId, with_hidden: bool = False) -> bool:
+        unhandled_error = self.get_node_unhandled_error(node_id, with_hidden)
+        return isinstance(unhandled_error, Exception)
 
     def get_node_result(self, node_id: NodeId, with_hidden: bool = False) -> t.Any:
         return self.node_results.get(node_id, with_hidden)

--- a/ml_pipeline_viewer/src/theme.ts
+++ b/ml_pipeline_viewer/src/theme.ts
@@ -11,5 +11,5 @@ export const GlobalStyle = createGlobalStyle`
     margin: 0;
     min-width: 1200px;
   }
-  
+
 `

--- a/tests/dag/oneof/test_nested_input_one_first_level_failure.py
+++ b/tests/dag/oneof/test_nested_input_one_first_level_failure.py
@@ -1,0 +1,68 @@
+import typing as t
+
+from ml_pipeline_engine.dag_builders.annotation.marks import Input
+from ml_pipeline_engine.dag_builders.annotation.marks import InputOneOf
+from ml_pipeline_engine.node import ProcessorBase
+from ml_pipeline_engine.types import PipelineChartLike
+from ml_pipeline_engine.node import ProcessorBase
+
+
+class SomeInput(ProcessorBase):
+    name = 'input'
+
+    def process(self, base_num: int, other_num: int) -> dict:
+        return {
+            'base_num': base_num,
+            'other_num': other_num,
+        }
+
+class SomeFeature0(ProcessorBase):
+    name = 'some_feature0'
+
+    async def process(self, ds_value: Input(SomeInput)) -> int:
+        return ds_value
+
+class FirstDataSource(ProcessorBase):
+    name = 'some_data_source'
+
+    def process(self, _: Input(SomeInput), inp: Input(SomeFeature0)) -> int:
+        raise Exception
+        
+class SecondDataSource(ProcessorBase):
+    name = 'some_data_source_second'
+
+    def process(self, _: Input(SomeInput)) -> int:
+        return 2
+
+class SomeFeature(ProcessorBase):
+    name = 'some_feature'
+
+    def process(self, ds_value: InputOneOf([FirstDataSource, SecondDataSource]), inp: Input(SomeInput)) -> int:
+        return ds_value
+
+class SomeFeature2(ProcessorBase):
+    name = 'some_feature2'
+
+    async def process(self, ds_value: Input(SomeFeature)) -> int:
+        return ds_value
+
+class FallbackFeature(ProcessorBase):
+    name = 'fallback_feature'
+
+    def process(self) -> int:
+        return 125
+
+class SomeVectorizer(ProcessorBase):
+    name = 'vectorizer'
+
+    def process(self, feature_value: InputOneOf([SomeFeature, FallbackFeature])) -> int:
+        return feature_value + 20
+    
+
+async def test_nested_input_one_of_first_level_failure_dag(
+    build_chart: t.Callable[..., PipelineChartLike],
+) -> None:
+    chart = build_chart(input_node=SomeInput, output_node=SomeVectorizer)
+    result = await chart.run(input_kwargs=dict(base_num=10, other_num=5))
+
+    assert result.value == 22

--- a/tests/dag/oneof/test_nested_input_one_first_level_success.py
+++ b/tests/dag/oneof/test_nested_input_one_first_level_success.py
@@ -1,0 +1,68 @@
+import typing as t
+
+from ml_pipeline_engine.dag_builders.annotation.marks import Input
+from ml_pipeline_engine.dag_builders.annotation.marks import InputOneOf
+from ml_pipeline_engine.node import ProcessorBase
+from ml_pipeline_engine.types import PipelineChartLike
+from ml_pipeline_engine.node import ProcessorBase
+
+
+class SomeInput(ProcessorBase):
+    name = 'input'
+
+    def process(self, base_num: int, other_num: int) -> dict:
+        return {
+            'base_num': base_num,
+            'other_num': other_num,
+        }
+
+class SomeFeature0(ProcessorBase):
+    name = 'some_feature0'
+
+    async def process(self, ds_value: Input(SomeInput)) -> int:
+        return ds_value
+
+class FirstDataSource(ProcessorBase):
+    name = 'some_data_source'
+
+    def process(self, _: Input(SomeInput), inp: Input(SomeFeature0)) -> int:
+        return 1
+        
+class SecondDataSource(ProcessorBase):
+    name = 'some_data_source_second'
+
+    def process(self, _: Input(SomeInput)) -> int:
+        return 2
+
+class SomeFeature(ProcessorBase):
+    name = 'some_feature'
+
+    def process(self, ds_value: InputOneOf([FirstDataSource, SecondDataSource]), inp: Input(SomeInput)) -> int:
+        return ds_value
+
+class SomeFeature2(ProcessorBase):
+    name = 'some_feature2'
+
+    async def process(self, ds_value: Input(SomeFeature)) -> int:
+        return ds_value
+
+class FallbackFeature(ProcessorBase):
+    name = 'fallback_feature'
+
+    def process(self) -> int:
+        return 125
+
+class SomeVectorizer(ProcessorBase):
+    name = 'vectorizer'
+
+    def process(self, feature_value: InputOneOf([SomeFeature, FallbackFeature])) -> int:
+        return feature_value + 20
+    
+
+async def test_nested_input_one_of_first_level_success_dag(
+    build_chart: t.Callable[..., PipelineChartLike],
+) -> None:
+    chart = build_chart(input_node=SomeInput, output_node=SomeVectorizer)
+    result = await chart.run(input_kwargs=dict(base_num=10, other_num=5))
+
+    assert result.value == 21

--- a/tests/dag/oneof/test_nested_input_one_only_necessary_branches.py
+++ b/tests/dag/oneof/test_nested_input_one_only_necessary_branches.py
@@ -1,0 +1,85 @@
+import typing as t
+
+from ml_pipeline_engine.dag_builders.annotation.marks import Input
+from ml_pipeline_engine.dag_builders.annotation.marks import InputOneOf
+from ml_pipeline_engine.node import ProcessorBase
+from ml_pipeline_engine.types import PipelineChartLike
+from ml_pipeline_engine.node import ProcessorBase
+
+count_calls = 0
+
+class SomeInput(ProcessorBase):
+    name = 'input'
+
+    def process(self, base_num: int, other_num: int) -> dict:
+        return {
+            'base_num': base_num,
+            'other_num': other_num,
+        }
+
+class SomeFeature0(ProcessorBase):
+    name = 'some_feature0'
+
+    async def process(self, ds_value: Input(SomeInput)) -> int:
+        return ds_value
+
+class FirstDataSource(ProcessorBase):
+    name = 'some_data_source'
+
+    def process(self, _: Input(SomeInput), inp: Input(SomeFeature0)) -> int:
+        global count_calls
+        count_calls += 1
+        return 1
+        
+class SecondDataSource(ProcessorBase):
+    name = 'some_data_source_second'
+
+    def process(self, _: Input(SomeInput)) -> int:
+        global count_calls
+        count_calls += 1
+        return 2
+
+class SomeFeature(ProcessorBase):
+    name = 'some_feature'
+
+    def process(self, ds_value: InputOneOf([FirstDataSource, SecondDataSource]), inp: Input(SomeInput)) -> int:
+        global count_calls
+        count_calls += 1
+        return ds_value
+
+class SomeFeature2(ProcessorBase):
+    name = 'some_feature2'
+
+    async def process(self, ds_value: Input(SomeFeature)) -> int:
+        return ds_value
+
+class FallbackFeature(ProcessorBase):
+    name = 'fallback_feature'
+
+    def process(self) -> int:
+        global count_calls
+        count_calls += 1
+        return 125
+
+class SomeVectorizer(ProcessorBase):
+    name = 'vectorizer'
+
+    def process(self, feature_value: InputOneOf([SomeFeature, FallbackFeature])) -> int:
+        return feature_value + 20
+
+class SomeMLModel(ProcessorBase):
+    name = 'some_model'
+
+    def process(self, vec_value: Input(SomeVectorizer)) -> float:
+        return (vec_value + 30) / 100
+    
+
+async def test_nested_input_one_of_only_necessary_branches_dag(
+    build_chart: t.Callable[..., PipelineChartLike],
+) -> None:
+    chart = build_chart(input_node=SomeInput, output_node=SomeMLModel)
+    result = await chart.run(input_kwargs=dict(base_num=10, other_num=5))
+
+    global count_calls
+
+    assert count_calls == 2

--- a/tests/dag/oneof/test_nested_input_one_second_level_failure.py
+++ b/tests/dag/oneof/test_nested_input_one_second_level_failure.py
@@ -1,0 +1,76 @@
+import typing as t
+
+from ml_pipeline_engine.dag_builders.annotation.marks import Input
+from ml_pipeline_engine.dag_builders.annotation.marks import InputOneOf
+from ml_pipeline_engine.node import ProcessorBase
+from ml_pipeline_engine.types import PipelineChartLike
+from ml_pipeline_engine.node import ProcessorBase
+from ml_pipeline_engine.dag import OneOfDoesNotHaveResultError
+
+
+class SomeInput(ProcessorBase):
+    name = 'input'
+
+    def process(self, base_num: int, other_num: int) -> dict:
+        return {
+            'base_num': base_num,
+            'other_num': other_num,
+        }
+
+class SomeFeature0(ProcessorBase):
+    name = 'some_feature0'
+
+    async def process(self, ds_value: Input(SomeInput)) -> int:
+        return ds_value
+
+class FirstDataSource(ProcessorBase):
+    name = 'some_data_source'
+
+    def process(self, _: Input(SomeInput), inp: Input(SomeFeature0)) -> int:
+        raise Exception
+        
+class SecondDataSource(ProcessorBase):
+    name = 'some_data_source_second'
+
+    def process(self, _: Input(SomeInput)) -> int:
+        raise Exception
+
+class SomeFeature(ProcessorBase):
+    name = 'some_feature'
+
+    def process(self, ds_value: InputOneOf([FirstDataSource, SecondDataSource]), inp: Input(SomeInput)) -> int:
+        return ds_value
+
+class SomeFeature2(ProcessorBase):
+    name = 'some_feature2'
+
+    async def process(self, ds_value: Input(SomeFeature)) -> int:
+        return ds_value
+
+class FallbackFeature(ProcessorBase):
+    name = 'fallback_feature'
+
+    def process(self) -> int:
+        raise Exception
+
+class SomeVectorizer(ProcessorBase):
+    name = 'vectorizer'
+
+    def process(self, feature_value: InputOneOf([SomeFeature, FallbackFeature])) -> int:
+        return feature_value + 20
+
+class SomeMLModel(ProcessorBase):
+    name = 'some_model'
+
+    def process(self, vec_value: Input(SomeVectorizer)) -> float:
+        return (vec_value + 30) / 100
+    
+
+async def test_nested_input_one_of_second_level_failure_dag(
+    build_chart: t.Callable[..., PipelineChartLike],
+) -> None:
+    chart = build_chart(input_node=SomeInput, output_node=SomeMLModel)
+    result = await chart.run(input_kwargs=dict(base_num=10, other_num=5))
+
+    assert result.error.__class__ == OneOfDoesNotHaveResultError
+

--- a/tests/dag/oneof/test_nested_input_one_second_level_success.py
+++ b/tests/dag/oneof/test_nested_input_one_second_level_success.py
@@ -1,0 +1,68 @@
+import typing as t
+
+from ml_pipeline_engine.dag_builders.annotation.marks import Input
+from ml_pipeline_engine.dag_builders.annotation.marks import InputOneOf
+from ml_pipeline_engine.node import ProcessorBase
+from ml_pipeline_engine.types import PipelineChartLike
+from ml_pipeline_engine.node import ProcessorBase
+
+
+class SomeInput(ProcessorBase):
+    name = 'input'
+
+    def process(self, base_num: int, other_num: int) -> dict:
+        return {
+            'base_num': base_num,
+            'other_num': other_num,
+        }
+
+class SomeFeature0(ProcessorBase):
+    name = 'some_feature0'
+
+    async def process(self, ds_value: Input(SomeInput)) -> int:
+        return ds_value
+
+class FirstDataSource(ProcessorBase):
+    name = 'some_data_source'
+
+    def process(self, _: Input(SomeInput), inp: Input(SomeFeature0)) -> int:
+        raise Exception
+        
+class SecondDataSource(ProcessorBase):
+    name = 'some_data_source_second'
+
+    def process(self, _: Input(SomeInput)) -> int:
+        raise Exception
+
+class SomeFeature(ProcessorBase):
+    name = 'some_feature'
+
+    def process(self, ds_value: InputOneOf([FirstDataSource, SecondDataSource]), inp: Input(SomeInput)) -> int:
+        return ds_value
+
+class SomeFeature2(ProcessorBase):
+    name = 'some_feature2'
+
+    async def process(self, ds_value: Input(SomeFeature)) -> int:
+        return ds_value
+
+class FallbackFeature(ProcessorBase):
+    name = 'fallback_feature'
+
+    def process(self) -> int:
+        return 125
+
+class SomeVectorizer(ProcessorBase):
+    name = 'vectorizer'
+
+    def process(self, feature_value: InputOneOf([SomeFeature, FallbackFeature])) -> int:
+        return feature_value + 20
+    
+
+async def test_nested_input_one_of_second_level_success_dag(
+    build_chart: t.Callable[..., PipelineChartLike],
+) -> None:
+    chart = build_chart(input_node=SomeInput, output_node=SomeVectorizer)
+    result = await chart.run(input_kwargs=dict(base_num=10, other_num=5))
+
+    assert result.value == 145

--- a/tests/visualization/test_visualization.py
+++ b/tests/visualization/test_visualization.py
@@ -111,7 +111,7 @@ async def test_basic(call_func: t.Callable) -> None:
 
         call_func(target)()
 
-        saved_config = (target / 'data.js').read_text()
+        saved_config = (target / 'data.js').read_text('utf-8')
         saved_config = json.loads(saved_config.replace('window.__GRAPH_DATA__ = ', ''))
 
         assert saved_config == {


### PR DESCRIPTION
1) Запуск графа из oneof и из основного метода отличаются способами получить reduced_dag. Тут пришлось немного подшаманить с атрибутами конечного узла подграфа oneof чтобы применить к нему такую же логику как к основному вызову.
2) Ошибки в oneof рейзятся сразу на уровне всего графа. Тут пришлось добавить снятие блокировок и вместо рейза ошибки сыпать в результат работы ноды one_of. Чтобы корректно обрабатывать эту ситуация в родительской ноде добавить в сторадж место для таких ошибок и делать проверку перед исполнением узла