### PR TITLE
feat: make process method abstract in ProcessorBase

### DIFF
--- a/ml_pipeline_engine/node/base_nodes.py
+++ b/ml_pipeline_engine/node/base_nodes.py
@@ -1,3 +1,4 @@
+import abc
 import typing as t
 
 from ml_pipeline_engine.node.enums import NodeType
@@ -15,8 +16,8 @@ class ProcessorBase(NodeBase):
 
     node_type = NodeType.processor.value
 
-    def process(self, *args: t.Any, **kwargs: t.Any) -> NodeResultT:
-        raise NotImplementedError('Method process() is not implemented')
+    @abc.abstractmethod
+    def process(self, *args: t.Any, **kwargs: t.Any) -> NodeResultT: ...
 
 
 class RecurrentProcessor(ProcessorBase, RecurrentProtocol):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,9 @@ def test_get_id() -> None:
         node_type = 'some-node-type'
         name = 'some-node'
 
+        def process(self) -> None:  # implementation of abstract method
+            pass
+
     assert get_node_id(SomeNode) == 'some-node-type__some-node'
     assert get_node_id(type(SomeNode())) == 'some-node-type__some-node'
 


### PR DESCRIPTION
В классах, наследуемых от `ProcessorBase` метод `process` должен быть всегда реализован. Сейчас нет проверки перед запуском, что это действительно так. Вместо этого происходит ошибка NotImplementedError во время работы приложения.

Предлагаю явно указать, что это абстрактный метод. В таком случае при старте приложения будет возникать `TypeError` в тех классах, где этот метод не определен. Таким образом пользователь библиотеки быстрее получит обратную связь, если что-то начнет делать не так (мне бы особенно помогло при переходе с версии библиотеки 2.0.0 на 2.1.1).
