### PR TITLE
feat: Add support for skipping artifact store save for tagged nodes

### DIFF
--- a/ml_pipeline_engine/node/enums.py
+++ b/ml_pipeline_engine/node/enums.py
@@ -14,7 +14,6 @@ class NodeType(str, enum.Enum):
 
     @classmethod
     def by_prefix(cls, value: str) -> 'NodeType':
-
         for item in cls:
             if value.startswith(item):
                 return cls(item)
@@ -30,3 +29,4 @@ class NodeTag(str, enum.Enum):
     process = 'process'
     thread = 'thread'
     non_async = 'non_async'
+    skip_store = 'skip_store'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "ml-pipeline-engine"
 readme = "README.md"
-version = "2.2.1"
+version = "2.3.0"
 authors = [
   "Konyaev Matvey",
   "Vasiliy Pankov",

--- a/tests/artifact_store/store/test_skip_tag.py
+++ b/tests/artifact_store/store/test_skip_tag.py
@@ -1,0 +1,69 @@
+import typing as t
+
+from ml_pipeline_engine.artifact_store.enums import DataFormat
+from ml_pipeline_engine.artifact_store.store.base import SerializedArtifactStore
+from ml_pipeline_engine.dag_builders.annotation.marks import Input
+from ml_pipeline_engine.node import ProcessorBase
+from ml_pipeline_engine.node import get_node_id
+from ml_pipeline_engine.node.enums import NodeTag
+from ml_pipeline_engine.types import NodeId
+from ml_pipeline_engine.types import NodeResultT
+from ml_pipeline_engine.types import PipelineChartLike
+from ml_pipeline_engine.types import PipelineContextLike
+
+
+class TestArtifactStore(SerializedArtifactStore):
+    def __init__(self, ctx: PipelineContextLike, store_log: t.List[NodeId]) -> None:
+        super().__init__(ctx)
+        self._log = store_log
+
+    async def save(self, node_id: NodeId, data: t.Any, fmt: DataFormat = None) -> None:  # noqa: ARG002
+        self._log.append(node_id)
+
+    async def load(self, node_id: NodeId) -> NodeResultT:
+        raise NotImplementedError
+
+
+class InvertNumber(ProcessorBase):
+    tags = (NodeTag.skip_store,)
+
+    def process(self, num: float) -> float:
+        return -num
+
+
+class AddConst(ProcessorBase):
+    tags = (NodeTag.non_async,)
+
+    def process(self, num: Input(InvertNumber), const: float = 0.1) -> float:
+        return num + const
+
+
+class DoubleNumber(ProcessorBase):
+    tags = (NodeTag.non_async,)
+
+    def process(self, num: Input(AddConst)) -> float:
+        return num * 2
+
+
+async def test_skip_tag_check(
+    build_chart: t.Callable[..., PipelineChartLike],
+) -> None:
+    store_log = []
+
+    chart = build_chart(
+        input_node=InvertNumber,
+        output_node=DoubleNumber,
+        artifact_store=lambda ctx: TestArtifactStore(ctx, store_log),
+    )
+    result = await chart.run(input_kwargs=dict(num=2.5))
+
+    assert result.value == -4.8
+    assert result.error is None
+
+    for node in (
+        AddConst,
+        DoubleNumber,
+    ):
+        assert get_node_id(node) in store_log
+
+    assert get_node_id(InvertNumber) not in store_log

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from ml_pipeline_engine.chart import PipelineChart
 from ml_pipeline_engine.dag_builders.annotation import build_dag as build_dag_base
 from ml_pipeline_engine.parallelism import process_pool_registry
 from ml_pipeline_engine.parallelism import threads_pool_registry
+from ml_pipeline_engine.types import ArtifactStoreLike
 from ml_pipeline_engine.types import PipelineChartLike
 
 
@@ -30,7 +31,6 @@ def get_loggers() -> t.Tuple[logging.Logger, ...]:
 
 @pytest.fixture
 def caplog_debug(caplog: pytest.LogCaptureFixture, get_loggers: t.Tuple[logging.Logger]) -> pytest.LogCaptureFixture:
-
     for logger in get_loggers:
         logger.addHandler(caplog.handler)
 
@@ -51,11 +51,15 @@ def model_name_op() -> str:
 
 @pytest.fixture
 def build_chart() -> t.Callable[..., PipelineChartLike]:
-
-    def wrap(*args: t.Any, **kwargs: t.Any) -> PipelineChartLike:
+    def wrap(
+        artifact_store: t.Optional[t.Type[ArtifactStoreLike]] = None,
+        *args: t.Any,
+        **kwargs: t.Any,
+    ) -> PipelineChartLike:
         return PipelineChart(
-            'no op',
-            build_dag_base(*args, **kwargs),
+            model_name='no op',
+            entrypoint=build_dag_base(*args, **kwargs),
+            artifact_store=artifact_store,
         )
 
     return wrap


### PR DESCRIPTION
Some nodes may contain data whose execution results should not be saved to the artifact store. 
To address this, the ability to mark such nodes with tag `skip_store` has been added.